### PR TITLE
Move to underscore suffix instead of r# like ryzz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # 0.2.0 (2024-02-01)
 
-- Add target attr
+- Deprecate r#for and r#type in favor of for_ and type_
 
 # 0.1.1 (2024-01-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# 0.2.0 (2024-02-01)
+
+- Add target attr
+
 # 0.1.1 (2024-01-17)
 
 - Add target attr

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "hyped"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "seq-macro",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyped"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,16 @@ impl Element {
         self
     }
 
+    #[deprecated(since = "0.1.1", note = "Please use type_ instead")]
+    pub fn r#type(self, value: impl Display) -> Self {
+        self.attr("type", value)
+    }
+
+    #[deprecated(since = "0.1.1", note = "Please use for_ instead")]
+    pub fn r#for(self, value: impl Display) -> Self {
+        self.attr("for", value)
+    }
+
     impl_attr!(class);
     impl_attr!(id);
     impl_attr!(charset);
@@ -124,8 +134,8 @@ impl Element {
     impl_attr!(scope);
     impl_attr!(title);
     impl_attr!(lang);
-    impl_attr!(r#type, "type");
-    impl_attr!(r#for, "for");
+    impl_attr!(type_, "type");
+    impl_attr!(for_, "for");
     impl_attr!(aria_controls, "aria-controls");
     impl_attr!(aria_expanded, "aria-expanded");
     impl_attr!(aria_label, "aria-label");
@@ -434,14 +444,14 @@ mod tests {
 
     #[test]
     fn bool_attr_works() {
-        let html = render(input().r#type("checkbox").checked());
+        let html = render(input().type_("checkbox").checked());
 
         assert_eq!(html, r#"<input type="checkbox" checked>"#)
     }
 
     #[test]
     fn multiple_attrs_spaced_correctly() {
-        let html = render(input().r#type("checkbox").checked().aria_label("label"));
+        let html = render(input().type_("checkbox").checked().aria_label("label"));
 
         assert_eq!(
             html,


### PR DESCRIPTION
This deprecates `r#for` and `r#type` attrs in favor of `for_` and `type_`